### PR TITLE
Update ajax-provider.ts

### DIFF
--- a/Bundles/ShopUi/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/ajax-provider/ajax-provider.ts
+++ b/Bundles/ShopUi/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/ajax-provider/ajax-provider.ts
@@ -57,6 +57,7 @@ export default class AjaxProvider extends Component {
         return new Promise<T>((resolve, reject) => {
             this.xhr.open(this.method, this.url);
 
+            this.xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
             this.headers.forEach((value: string, key: string) => {
                 this.xhr.setRequestHeader(key, value);
             });

--- a/Bundles/ShopUi/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/ajax-provider/ajax-provider.ts
+++ b/Bundles/ShopUi/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/ajax-provider/ajax-provider.ts
@@ -56,6 +56,12 @@ export default class AjaxProvider extends Component {
 
         return new Promise<T>((resolve, reject) => {
             this.xhr.open(this.method, this.url);
+
+            this.headers.forEach((value: string, key: string) => {
+                this.xhr.setRequestHeader(key, value);
+            });
+
+            this.xhr.open(this.method, this.url);
             this.xhr.responseType = this.responseType;
             this.xhr.addEventListener('load', (event: Event) => this.onRequestLoad(resolve, reject, event));
             this.xhr.addEventListener('error', (event: Event) => this.onRequestError(reject, event));


### PR DESCRIPTION
Type: Feature request
Module: ajax-provider
Version: unknown
Description: Add ability to set custom headers. Also I suggest add default one like
```js
this.xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
```
